### PR TITLE
revert solidity to 0.5.13

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 contract Migrations {
     address public owner;

--- a/contracts/SyscoinBattleManager.sol
+++ b/contracts/SyscoinBattleManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import './interfaces/SyscoinClaimManagerI.sol';
 import './interfaces/SyscoinSuperblocksI.sol';

--- a/contracts/SyscoinClaimManager.sol
+++ b/contracts/SyscoinClaimManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import './interfaces/SyscoinSuperblocksI.sol';
 import './interfaces/SyscoinClaimManagerI.sol';

--- a/contracts/SyscoinDepositsManager.sol
+++ b/contracts/SyscoinDepositsManager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 

--- a/contracts/SyscoinErrorCodes.sol
+++ b/contracts/SyscoinErrorCodes.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 // @dev - SyscoinSuperblocks error codes
 contract SyscoinErrorCodes {

--- a/contracts/SyscoinParser/SyscoinMessageLibrary.sol
+++ b/contracts/SyscoinParser/SyscoinMessageLibrary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "solidity-rlp/contracts/RLPReader.sol";
 

--- a/contracts/SyscoinSuperblocks.sol
+++ b/contracts/SyscoinSuperblocks.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import './interfaces/SyscoinSuperblocksI.sol';
 import "./SyscoinErrorCodes.sol";

--- a/contracts/SyscoinSuperblocksForTests.sol
+++ b/contracts/SyscoinSuperblocksForTests.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "./SyscoinSuperblocks.sol";
 

--- a/contracts/SyscoinTransactionProcessor.sol
+++ b/contracts/SyscoinTransactionProcessor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 // Interface contract to be implemented by SyscoinERC20Manager
 interface SyscoinTransactionProcessor {

--- a/contracts/token/SyscoinERC20.sol
+++ b/contracts/token/SyscoinERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";

--- a/contracts/token/SyscoinERC20Manager.sol
+++ b/contracts/token/SyscoinERC20Manager.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../interfaces/SyscoinERC20I.sol";

--- a/contracts/token/SyscoinERC20ManagerForTests.sol
+++ b/contracts/token/SyscoinERC20ManagerForTests.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "./SyscoinERC20Manager.sol";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7604,7 +7604,7 @@
     },
     "solc": {
       "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.15.tgz",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.13.tgz",
       "integrity": "sha512-uI+7XtBu/0CXRc8IMjzxbh0haLwaBF32VxAkkks06zEk+mVcsQbHdjvojXX6zQYtZVuXdVYPVccoIjEhvvqKnQ==",
       "requires": {
         "command-exists": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "js-sha3": "^0.8.0",
     "openzeppelin-solidity": "^2.4.0",
     "openzeppelin-test-helpers": "^0.4.3",
-    "solc": "^0.5.15",
+    "solc": "^0.5.13",
     "solidity-rlp": "^2.0.1",
     "truffle": "^5.1.5",
     "truffle-assertions": "^0.9.1",

--- a/test/TestSyscoinMessageLibrary.sol
+++ b/test/TestSyscoinMessageLibrary.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.15;
+pragma solidity ^0.5.13;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.5.15",
+      version: "0.5.13",
       settings: {
         optimizer: {
           enabled: true,


### PR DESCRIPTION
instabul compiled contracts may have issues with OZ Proxy contracts: see https://forum.openzeppelin.com/t/openzeppelin-upgradeable-contracts-affected-by-istanbul-hardfork/1616

also does not verify on etherscan